### PR TITLE
Change scope of hamcrest-junit to test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-junit</artifactId>
             <version>2.0.0.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Change scope of hamcrest-junit to test to prevent it from importing JUnit 4 into the project with scope compile